### PR TITLE
Exceptions to json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Which will result in:
 }
 ```
 
+For a collection response, data is an array of resources.
+Errors can also be send as response, even automatically by exceptions.
+
 Examples for all kind of responses are in the [/examples](/examples) directory.
 
 

--- a/examples/errors_exception_direct.php
+++ b/examples/errors_exception_direct.php
@@ -1,0 +1,29 @@
+<?php
+
+ini_set('display_errors', 1);
+error_reporting(-1);
+
+require '../vendor/autoload.php';
+
+/**
+ * normally you don't need to set a content type
+ * however it can be handy for debugging
+ */
+
+$content_type = \alsvanzelf\jsonapi\base::CONTENT_TYPE_DEBUG;
+
+/**
+ * via an exception
+ * 
+ * @note echo'ing the exception has the same effect as using ->send_response()
+ */
+
+try {
+	$friendly_message = 'We don\'t know this user.';
+	$about_link = 'www.example.com/search';
+	throw new \alsvanzelf\jsonapi\exception('unknown user', 404, $previous=null, $friendly_message, $about_link);
+}
+catch (Exception $e) {
+	echo $e;
+	exit;
+}

--- a/examples/errors_exception_direct.php
+++ b/examples/errors_exception_direct.php
@@ -8,13 +8,17 @@ require '../vendor/autoload.php';
 /**
  * via an exception
  * 
+ * @note previous exceptions will be added as well
+ * @note exceptions only output file, line, trace if the display_errors directive is true
+ *       you can tune it with that, or by setting jsonapi\base::$debug to false
  * @note echo'ing the exception has the same effect as using ->send_response()
  */
 
 try {
+	$http_status = \alsvanzelf\jsonapi\base::STATUS_NOT_FOUND;
 	$friendly_message = 'We don\'t know this user.';
 	$about_link = 'www.example.com/search';
-	throw new \alsvanzelf\jsonapi\exception('unknown user', 404, $previous=null, $friendly_message, $about_link);
+	throw new \alsvanzelf\jsonapi\exception('unknown user', $http_status, $previous=null, $friendly_message, $about_link);
 }
 catch (Exception $e) {
 	echo $e;

--- a/examples/errors_exception_direct.php
+++ b/examples/errors_exception_direct.php
@@ -15,7 +15,7 @@ require '../vendor/autoload.php';
  */
 
 try {
-	$http_status = \alsvanzelf\jsonapi\base::STATUS_NOT_FOUND;
+	$http_status = \alsvanzelf\jsonapi\response::STATUS_NOT_FOUND;
 	$friendly_message = 'We don\'t know this user.';
 	$about_link = 'www.example.com/search';
 	throw new \alsvanzelf\jsonapi\exception('unknown user', $http_status, $previous=null, $friendly_message, $about_link);

--- a/examples/errors_exception_direct.php
+++ b/examples/errors_exception_direct.php
@@ -1,5 +1,7 @@
 <?php
 
+use alsvanzelf\jsonapi;
+
 ini_set('display_errors', 1);
 error_reporting(-1);
 
@@ -15,10 +17,10 @@ require '../vendor/autoload.php';
  */
 
 try {
-	$http_status = \alsvanzelf\jsonapi\response::STATUS_NOT_FOUND;
+	$http_status = jsonapi\response::STATUS_NOT_FOUND;
 	$friendly_message = 'We don\'t know this user.';
 	$about_link = 'www.example.com/search';
-	throw new \alsvanzelf\jsonapi\exception('unknown user', $http_status, $previous=null, $friendly_message, $about_link);
+	throw new jsonapi\exception('unknown user', $http_status, $previous=null, $friendly_message, $about_link);
 }
 catch (Exception $e) {
 	echo $e;

--- a/examples/errors_exception_native.php
+++ b/examples/errors_exception_native.php
@@ -21,5 +21,4 @@ try {
 catch (Exception $e) {
 	$jsonapi = new jsonapi\errors($e);
 	$jsonapi->send_response();
-	exit;
 }

--- a/examples/errors_exception_native.php
+++ b/examples/errors_exception_native.php
@@ -24,4 +24,5 @@ try {
 catch (Exception $e) {
 	$jsonapi = new \alsvanzelf\jsonapi\errors($e);
 	$jsonapi->send_response($content_type);
+	exit;
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -29,6 +29,7 @@
 	<h3>Errors</h3>
 	<ul>
 		<li><a href="errors_exception.php">Via an exception</a></li>
+		<li><a href="errors_exception_direct.php">Via jsonapi's custom exception</a></li>
 		<li><a href="errors_all_options.php">All options</a></li>
 	</ul>
 	

--- a/examples/index.html
+++ b/examples/index.html
@@ -28,8 +28,8 @@
 	
 	<h3>Errors</h3>
 	<ul>
-		<li><a href="errors_exception.php">Via an exception</a></li>
 		<li><a href="errors_exception_direct.php">Via jsonapi's custom exception</a></li>
+		<li><a href="errors_exception_native.php">Via php's native exception</a></li>
 		<li><a href="errors_all_options.php">All options</a></li>
 	</ul>
 	

--- a/src/errors.php
+++ b/src/errors.php
@@ -17,19 +17,9 @@ namespace alsvanzelf\jsonapi;
  * - meta data @see ->add_meta() or ->fill_meta()
  * - self link @see ->set_self_link()
  * 
- * @note ease error handling by using a jsonapi\exception
- * 
- * ```
- * try {
- *     throw new jsonapi\exception('something went wrong');
- * }
- * catch (Exception $e) {
- *     $e->send_response();
- *     exit;
- * }
- * ```
- * 
- * @see jsonapi\exception::__toString() when you want to use your own exception handling
+ * @note ease error handling by using a jsonapi\exception instead
+ *       @see examples/errors_exception_direct.php
+ *       @see or jsonapi\exception::__toString() when you want to use your own exception handling
  */
 
 class errors extends response {

--- a/src/errors.php
+++ b/src/errors.php
@@ -17,9 +17,9 @@ namespace alsvanzelf\jsonapi;
  * - meta data @see ->add_meta() or ->fill_meta()
  * - self link @see ->set_self_link()
  * 
- * @note ease error handling by using a jsonapi\exception instead
+ * @note ease error handling by using a jsonapi\exception
  *       @see examples/errors_exception_direct.php
- *       @see or jsonapi\exception::__toString() when you want to use your own exception handling
+ *       @see jsonapi\exception::__toString() when you want to use your own exception handling
  */
 
 class errors extends response {

--- a/src/errors.php
+++ b/src/errors.php
@@ -189,7 +189,7 @@ public function fill_errors($errors) {
  * 
  * @todo hide exception meta data on production environments
  */
-public function add_exception($exception=null, $friendly_message=null, $about_link=null) {
+public function add_exception($exception, $friendly_message=null, $about_link=null) {
 	$previous_exception = $exception->getPrevious();
 	if ($previous_exception) {
 		$this->add_exception($previous_exception);

--- a/src/errors.php
+++ b/src/errors.php
@@ -17,15 +17,19 @@ namespace alsvanzelf\jsonapi;
  * - meta data @see ->add_meta() or ->fill_meta()
  * - self link @see ->set_self_link()
  * 
- * @note ease error handling by adding this in your own exception handling
+ * @note ease error handling by using a jsonapi\exception
  * 
  * ```
- * public function __toString() {
- *     $jsonapi = new \alsvanzelf\jsonapi\errors($this);
- *     $jsonapi->send_response();
- *     return '';
+ * try {
+ *     throw new jsonapi\exception('something went wrong');
+ * }
+ * catch (Exception $e) {
+ *     $e->send_response();
+ *     exit;
  * }
  * ```
+ * 
+ * @see jsonapi\exception::__toString() when you want to use your own exception handling
  */
 
 class errors extends base {

--- a/src/exception.php
+++ b/src/exception.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace alsvanzelf\jsonapi;
+
+/**
+ * custom exception for use in jsonapi projects
+ * echo'ing the exception (or using ->send_response()) output a errors collection response
+ * 
+ * @note throwing the exception alone doesn't give you json output
+ */
+
+class exception extends \Exception {
+
+protected $friendly_message;
+protected $about_link;
+
+public function __construct($message='', $code=0, $previous=null, $friendly_message=null, $about_link=null) {
+	parent::__construct($message, $code, $previous);
+	
+	$this->set_friendly_message($friendly_message);
+	$this->set_about_link($about_link);
+}
+
+public function set_friendly_message($message) {
+	$this->friendly_message = $message;
+}
+
+public function set_about_link($link) {
+	$this->about_link = $link;
+}
+
+public function send_response($content_type=errors::CONTENT_TYPE_OFFICIAL, $encode_options=448, $response=null) {
+	$jsonapi = new errors($this, $this->friendly_message, $this->about_link);
+	$jsonapi->send_response($content_type, $encode_options, $response);
+	exit;
+}
+
+public function __toString() {
+	$this->send_response();
+	return '';
+}
+
+}

--- a/src/exception.php
+++ b/src/exception.php
@@ -25,7 +25,7 @@ protected $about_link;
  * 
  * @param string    $message
  * @param integer   $code             optional, defaults to 500
- *                                    if using one of the predefined ones in response::STATUS_*
+ *                                    if using one of the predefined ones in jsonapi\response::STATUS_*
  *                                    sends out those as http status
  * @param Exception $previous
  * @param string    $friendly_message optional, which message to output to clients
@@ -67,7 +67,7 @@ public function set_about_link($about_link) {
  * 
  * @see errors->send_response()
  */
-public function send_response($content_type=null, $encode_options=448, $response=null) {
+public function send_response($content_type=null, $encode_options=null, $response=null) {
 	$jsonapi = new errors($this, $this->friendly_message, $this->about_link);
 	$jsonapi->send_response($content_type, $encode_options, $response);
 	exit;

--- a/src/exception.php
+++ b/src/exception.php
@@ -11,30 +11,74 @@ namespace alsvanzelf\jsonapi;
 
 class exception extends \Exception {
 
+/**
+ * internal data containers
+ */
 protected $friendly_message;
 protected $about_link;
 
+/**
+ * custom exception for usage by jsonapi projects
+ * when echo'd, sends a jsonapi\errors response with the exception in it
+ * 
+ * can be thrown as a normal exception, optionally with two extra parameters
+ * 
+ * @param string    $message
+ * @param integer   $code             optional, defaults to 500
+ *                                    if using one of the predefined ones in response::STATUS_*
+ *                                    sends out those as http status
+ * @param Exception $previous
+ * @param string    $friendly_message optional, which message to output to clients
+ *                                    the exception $message is hidden unless base::$debug is true
+ * @param string    $about_link       optional, a url to send clients to for more explanation
+ *                                    i.e. a link to the api documentation
+ */
 public function __construct($message='', $code=0, $previous=null, $friendly_message=null, $about_link=null) {
 	parent::__construct($message, $code, $previous);
 	
-	$this->set_friendly_message($friendly_message);
-	$this->set_about_link($about_link);
+	if ($friendly_message) {
+		$this->set_friendly_message($friendly_message);
+	}
+	if ($about_link) {
+		$this->set_about_link($about_link);
+	}
 }
 
-public function set_friendly_message($message) {
-	$this->friendly_message = $message;
+/**
+ * sets a main user facing message
+ * 
+ * @see error->set_friendly_message()
+ */
+public function set_friendly_message($friendly_message) {
+	$this->friendly_message = $friendly_message;
 }
 
-public function set_about_link($link) {
-	$this->about_link = $link;
+/**
+ * sets a link which can help in solving the problem
+ * 
+ * @see error->set_about_link()
+ */
+public function set_about_link($about_link) {
+	$this->about_link = $about_link;
 }
 
-public function send_response($content_type=response::CONTENT_TYPE_OFFICIAL, $encode_options=448, $response=null) {
+/**
+ * sends out the json response of an jsonapi\errors object to the browser
+ * 
+ * @see errors->send_response()
+ */
+public function send_response($content_type=null, $encode_options=448, $response=null) {
 	$jsonapi = new errors($this, $this->friendly_message, $this->about_link);
 	$jsonapi->send_response($content_type, $encode_options, $response);
 	exit;
 }
 
+/**
+ * alias for ->send_response()
+ * 
+ * @return string empty for sake of correctness
+ *                as ->send_response() already echo's the json and terminates script execution
+ */
 public function __toString() {
 	$this->send_response();
 	return '';

--- a/src/exception.php
+++ b/src/exception.php
@@ -29,7 +29,7 @@ public function set_about_link($link) {
 	$this->about_link = $link;
 }
 
-public function send_response($content_type=errors::CONTENT_TYPE_OFFICIAL, $encode_options=448, $response=null) {
+public function send_response($content_type=response::CONTENT_TYPE_OFFICIAL, $encode_options=448, $response=null) {
 	$jsonapi = new errors($this, $this->friendly_message, $this->about_link);
 	$jsonapi->send_response($content_type, $encode_options, $response);
 	exit;


### PR DESCRIPTION
This    makes the already advised custom exception directly available.
- [x] write a bit more docblocks in `exception`
- [x] update after merging https://github.com/lode/jsonapi/pull/6
