### PR TITLE
Support local ids

### DIFF
--- a/src/helpers/Validator.php
+++ b/src/helpers/Validator.php
@@ -12,6 +12,7 @@ use alsvanzelf\jsonapi\interfaces\ResourceInterface;
 class Validator {
 	const OBJECT_CONTAINER_TYPE          = 'type';
 	const OBJECT_CONTAINER_ID            = 'id';
+	const OBJECT_CONTAINER_LID           = 'lid';
 	const OBJECT_CONTAINER_ATTRIBUTES    = 'attributes';
 	const OBJECT_CONTAINER_RELATIONSHIPS = 'relationships';
 	

--- a/src/helpers/Validator.php
+++ b/src/helpers/Validator.php
@@ -85,7 +85,7 @@ class Validator {
 	 */
 	public function claimUsedResourceIdentifier(ResourceInterface $resource) {
 		if ($resource->getResource()->hasIdentification() === false) {
-			throw new InputException('can not validate resource without identifier, set type and id first');
+			throw new InputException('can not validate resource without identifier, set type and id/lid first');
 		}
 		
 		$resourceKey = $resource->getResource()->getIdentificationKey();

--- a/src/objects/ResourceIdentifierObject.php
+++ b/src/objects/ResourceIdentifierObject.php
@@ -16,6 +16,8 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 	protected $type;
 	/** @var string */
 	protected $id;
+	/** @var string */
+	protected $lid;
 	/** @var MetaObject */
 	protected $meta;
 	/** @var Validator */
@@ -42,6 +44,7 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 		// always mark as used, as these keys are reserved
 		$this->validator->claimUsedFields($fieldNames=['type'], Validator::OBJECT_CONTAINER_TYPE);
 		$this->validator->claimUsedFields($fieldNames=['id'], Validator::OBJECT_CONTAINER_ID);
+		$this->validator->claimUsedFields($fieldNames=['lid'], Validator::OBJECT_CONTAINER_LID);
 	}
 	
 	/**
@@ -73,9 +76,28 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 	
 	/**
 	 * @param string|int $id will be casted to a string
+	 * 
+	 * @throws DuplicateException if localId is already set
 	 */
 	public function setId($id) {
+		if ($this->lid !== null) {
+			throw new DuplicateException('id is not allowed when localId is already set');
+		}
+		
 		$this->id = (string) $id;
+	}
+	
+	/**
+	 * @param string|int $localId will be casted to a string
+	 * 
+	 * @throws DuplicateException if normal id is already set
+	 */
+	public function setLocalId($localId) {
+		if ($this->id !== null) {
+			throw new DuplicateException('localId is not allowed when id is already set');
+		}
+		
+		$this->lid = (string) $localId;
 	}
 	
 	/**
@@ -178,6 +200,9 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 		
 		if ($this->id !== null) {
 			$array['id'] = $this->id;
+		}
+		elseif ($this->lid !== null) {
+			$array['lid'] = $this->lid;
 		}
 		
 		if ($this->meta !== null && $this->meta->isEmpty() === false) {

--- a/src/objects/ResourceIdentifierObject.php
+++ b/src/objects/ResourceIdentifierObject.php
@@ -3,6 +3,7 @@
 namespace alsvanzelf\jsonapi\objects;
 
 use alsvanzelf\jsonapi\exceptions\Exception;
+use alsvanzelf\jsonapi\exceptions\DuplicateException;
 use alsvanzelf\jsonapi\helpers\AtMemberManager;
 use alsvanzelf\jsonapi\helpers\Validator;
 use alsvanzelf\jsonapi\interfaces\ObjectInterface;

--- a/src/objects/ResourceIdentifierObject.php
+++ b/src/objects/ResourceIdentifierObject.php
@@ -88,6 +88,10 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 	}
 	
 	/**
+	 * set a local id to connect resources to each other when created on the client
+	 * 
+	 * @note this should not be used to send back from the server to the client
+	 * 
 	 * @param string|int $localId will be casted to a string
 	 * 
 	 * @throws DuplicateException if normal id is already set

--- a/src/objects/ResourceIdentifierObject.php
+++ b/src/objects/ResourceIdentifierObject.php
@@ -118,7 +118,7 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 	 * @return ResourceIdentifierObject
 	 */
 	public static function fromResourceObject(ResourceObject $resourceObject) {
-		$resourceIdentifierObject = new self($resourceObject->type, $resourceObject->id);
+		$resourceIdentifierObject = new self($resourceObject->type, $resourceObject->primaryId());
 		
 		if ($resourceObject->meta !== null) {
 			$resourceIdentifierObject->setMetaObject($resourceObject->meta);
@@ -149,7 +149,7 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 	 * @return boolean
 	 */
 	public function hasIdentification() {
-		return ($this->type !== null && $this->id !== null);
+		return ($this->type !== null && $this->primaryId() !== null);
 	}
 	
 	/**
@@ -166,7 +166,7 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 			throw new Exception('resource has no identification yet');
 		}
 		
-		return $this->type.'|'.$this->id;
+		return $this->type.'|'.$this->primaryId();
 	}
 	
 	/**
@@ -177,7 +177,7 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 	 * @inheritDoc
 	 */
 	public function isEmpty() {
-		if ($this->type !== null || $this->id !== null) {
+		if ($this->type !== null || $this->primaryId() !== null) {
 			return false;
 		}
 		if ($this->meta !== null && $this->meta->isEmpty() === false) {
@@ -221,5 +221,17 @@ class ResourceIdentifierObject implements ObjectInterface, ResourceInterface {
 	 */
 	public function getResource($identifierOnly=false) {
 		return $this;
+	}
+	
+	/**
+	 * @internal
+	 */
+	
+	private function primaryId() {
+		if ($this->lid !== null) {
+			return $this->lid;
+		}
+		
+		return $this->id;
 	}
 }


### PR DESCRIPTION
Implements https://github.com/lode/jsonapi/issues/49

To Do:

- [x] check if need to pass `lid` in more places we now use `id` only
- [x] explain it is only allowed for client documents
- [x] tests