### PR TITLE
Fix crash on request parsing with different kinds of requests / $_SERVER variables being set

### DIFF
--- a/src/helpers/RequestParser.php
+++ b/src/helpers/RequestParser.php
@@ -46,12 +46,15 @@ class RequestParser {
 	 * @return self
 	 */
 	public static function fromSuperglobals() {
-		$selfLink = $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+		$selfLink = '';
+		if (isset($_SERVER['REQUEST_SCHEME']) && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
+			$selfLink = $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+		}
 		
 		$queryParameters = $_GET;
 		
 		$document = $_POST;
-		if ($document === []) {
+		if ($document === [] && isset($_SERVER['CONTENT_TYPE'])) {
 			$documentIsJsonapi = (strpos($_SERVER['CONTENT_TYPE'], Document::CONTENT_TYPE_OFFICIAL) !== false);
 			$documentIsJson    = (strpos($_SERVER['CONTENT_TYPE'], Document::CONTENT_TYPE_DEBUG)    !== false);
 			

--- a/tests/helpers/RequestParserTest.php
+++ b/tests/helpers/RequestParserTest.php
@@ -91,7 +91,11 @@ class RequestParserTest extends TestCase {
 	}
 	
 	public function testFromSuperglobals_WithoutServerContext() {
-		$_SERVER = [];
+		unset($_SERVER['REQUEST_SCHEME']);
+		unset($_SERVER['HTTP_HOST']);
+		unset($_SERVER['REQUEST_URI']);
+		unset($_SERVER['CONTENT_TYPE']);
+		
 		$_GET    = [];
 		$_POST   = [];
 		

--- a/tests/helpers/RequestParserTest.php
+++ b/tests/helpers/RequestParserTest.php
@@ -90,6 +90,16 @@ class RequestParserTest extends TestCase {
 		$this->assertSame([], $requestParser->getDocument());
 	}
 	
+	public function testFromSuperglobals_WithoutServerContext() {
+		$_SERVER = [];
+		$_GET    = [];
+		$_POST   = [];
+		
+		$requestParser = RequestParser::fromSuperglobals();
+		
+		$this->assertSame([], $requestParser->getDocument());
+	}
+	
 	public function testFromPsrRequest_WithRequestInterface() {
 		$queryParameters = [
 			'include' => 'ship,ship.wing',


### PR DESCRIPTION
Mostly on non-POST requests the `$_SERVER['CONTENT_TYPE']` might be missing which can crash the request parsing.