### PR TITLE
fix psr4 namespace issues

### DIFF
--- a/tests/helpers/AtMemberManagerTest.php
+++ b/tests/helpers/AtMemberManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace alsvanzelf\jsonapiTests;
+namespace alsvanzelf\jsonapiTests\helpers;
 
 use alsvanzelf\jsonapi\exceptions\InputException;
 use alsvanzelf\jsonapiTests\helpers\TestableNonTraitAtMemberManager as AtMemberManager;

--- a/tests/helpers/HttpStatusCodeManagerTest.php
+++ b/tests/helpers/HttpStatusCodeManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace alsvanzelf\jsonapiTests;
+namespace alsvanzelf\jsonapiTests\helpers;
 
 use alsvanzelf\jsonapi\exceptions\InputException;
 use alsvanzelf\jsonapiTests\helpers\TestableNonTraitHttpStatusCodeManager as HttpStatusCodeManager;

--- a/tests/helpers/LinksManagerTest.php
+++ b/tests/helpers/LinksManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace alsvanzelf\jsonapiTests;
+namespace alsvanzelf\jsonapiTests\helpers;
 
 use alsvanzelf\jsonapi\exceptions\InputException;
 use alsvanzelf\jsonapi\objects\LinkObject;

--- a/tests/helpers/ProfileAliasManagerTest.php
+++ b/tests/helpers/ProfileAliasManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace alsvanzelf\jsonapiTests;
+namespace alsvanzelf\jsonapiTests\helpers;
 
 use alsvanzelf\jsonapi\exceptions\InputException;
 use alsvanzelf\jsonapi\objects\ProfileLinkObject;


### PR DESCRIPTION
was getting 

```
Class alsvanzelf\jsonapiTests\AtMemberManagerTest located in ./vendor/alsvanzelf/jsonapi/tests/helpers/AtMemberManagerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class alsvanzelf\jsonapiTests\HttpStatusCodeManagerTest located in ./vendor/alsvanzelf/jsonapi/tests/helpers/HttpStatusCodeManagerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class alsvanzelf\jsonapiTests\ProfileAliasManagerTest located in ./vendor/alsvanzelf/jsonapi/tests/helpers/ProfileAliasManagerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class alsvanzelf\jsonapiTests\LinksManagerTest located in ./vendor/alsvanzelf/jsonapi/tests/helpers/LinksManagerTest.php does not comply with psr-4 autoloading standard. Skipping.
```

errors while installing