### PR TITLE
Add porcelain method to easily blame headers for errors

### DIFF
--- a/examples/errors_all_options.php
+++ b/examples/errors_all_options.php
@@ -16,6 +16,7 @@ $errorSpecApi = new ErrorObject();
 // mark the cause of the error
 $errorSpecApi->blameJsonPointer($pointer='/data/attributes/title');
 $errorSpecApi->blameQueryParameter($parameter='filter');
+$errorSpecApi->blameHeader($headerName='X-Foo');
 
 // an identifier useful for helpdesk purposes
 $errorSpecApi->setUniqueIdentifier($id=42);

--- a/src/objects/ErrorObject.php
+++ b/src/objects/ErrorObject.php
@@ -195,6 +195,15 @@ class ErrorObject implements ObjectInterface {
 	}
 	
 	/**
+	 * blame the header from the request causing this error
+	 * 
+	 * @param  string $headerName
+	 */
+	public function blameHeader($headerName) {
+		$this->addSource('header', $headerName);
+	}
+	
+	/**
 	 * @param string $key
 	 * @param mixed  $value
 	 */

--- a/tests/example_output/errors_all_options/errors_all_options.json
+++ b/tests/example_output/errors_all_options/errors_all_options.json
@@ -42,7 +42,8 @@
 			},
 			"source": {
 				"pointer": "/data/attributes/title",
-				"parameter": "filter"
+				"parameter": "filter",
+				"header": "X-Foo"
 			},
 			"meta": {
 				"foo": "bar",
@@ -63,7 +64,7 @@
 				"message": "please don't throw things",
 				"code": 500,
 				"file": "/errors_all_options.php",
-				"line": 30
+				"line": 31
 			}
 		},
 		{
@@ -73,7 +74,7 @@
 				"message": "something went wrong!",
 				"code": 0,
 				"file": "/errors_all_options.php",
-				"line": 29
+				"line": 30
 			}
 		},
 		{

--- a/tests/example_output/errors_all_options/errors_all_options.php
+++ b/tests/example_output/errors_all_options/errors_all_options.php
@@ -12,6 +12,7 @@ class errors_all_options {
 		$errorSpecApi = new ErrorObject();
 		$errorSpecApi->blameJsonPointer($pointer='/data/attributes/title');
 		$errorSpecApi->blameQueryParameter($parameter='filter');
+		$errorSpecApi->blameHeader($headerName='X-Foo');
 		$errorSpecApi->setUniqueIdentifier($id=42);
 		$errorSpecApi->addMeta($key='foo', $value='bar');
 		$errorSpecApi->setHttpStatusCode($httpStatusCode=404);

--- a/tests/objects/ErrorObjectTest.php
+++ b/tests/objects/ErrorObjectTest.php
@@ -161,7 +161,15 @@ class ErrorObjectTest extends TestCase {
 		$this->assertFalse($errorObject->isEmpty());
 		
 		$errorObject = new ErrorObject();
+		$errorObject->addSource('pointer', '/bar');
+		$this->assertFalse($errorObject->isEmpty());
+		
+		$errorObject = new ErrorObject();
 		$errorObject->addSource('parameter', 'bar');
+		$this->assertFalse($errorObject->isEmpty());
+		
+		$errorObject = new ErrorObject();
+		$errorObject->addSource('header', 'X-Bar');
 		$this->assertFalse($errorObject->isEmpty());
 		
 		$errorObject = new ErrorObject();


### PR DESCRIPTION
Following the discussion in https://github.com/json-api/json-api/issues/1514