### PR TITLE
Allow to test for empty include query parameter

### DIFF
--- a/src/helpers/RequestParser.php
+++ b/src/helpers/RequestParser.php
@@ -196,6 +196,10 @@ class RequestParser {
 	 * }
 	 */
 	public function getSortFields(array $options=[]) {
+		if ($this->queryParameters['sort'] === '') {
+			return [];
+		}
+		
 		$fields = explode(',', $this->queryParameters['sort']);
 		
 		$options = array_merge(self::$defaults, $options);

--- a/src/helpers/RequestParser.php
+++ b/src/helpers/RequestParser.php
@@ -127,6 +127,10 @@ class RequestParser {
 	 * @return string[]|array
 	 */
 	public function getIncludePaths(array $options=[]) {
+		if ($this->queryParameters['include'] === '') {
+			return [];
+		}
+		
 		$includePaths = explode(',', $this->queryParameters['include']);
 		
 		$options = array_merge(self::$defaults, $options);

--- a/tests/helpers/RequestParserTest.php
+++ b/tests/helpers/RequestParserTest.php
@@ -253,6 +253,14 @@ class RequestParserTest extends TestCase {
 		$this->assertSame(['foo', 'bar', 'baz.baf'], $requestParser->getIncludePaths($options));
 	}
 	
+	public function testGetIncludePaths_Empty() {
+		$queryParameters = ['include' => ''];
+		$requestParser = new RequestParser($selfLink='', $queryParameters);
+		
+		$this->assertTrue($requestParser->hasIncludePaths());
+		$this->assertSame([], $requestParser->getIncludePaths());
+	}
+	
 	public function testHasSparseFieldset() {
 		$requestParser = new RequestParser();
 		$this->assertFalse($requestParser->hasSparseFieldset('foo'));

--- a/tests/helpers/RequestParserTest.php
+++ b/tests/helpers/RequestParserTest.php
@@ -310,6 +310,14 @@ class RequestParserTest extends TestCase {
 		$this->assertSame(['foo', '-bar'], $requestParser->getSortFields($options));
 	}
 	
+	public function testGetSortFields_Empty() {
+		$queryParameters = ['sort' => ''];
+		$requestParser = new RequestParser($selfLink='', $queryParameters);
+		
+		$this->assertTrue($requestParser->hasSortFields());
+		$this->assertSame([], $requestParser->getSortFields());
+	}
+	
 	public function testHasPagination() {
 		$requestParser = new RequestParser();
 		$this->assertFalse($requestParser->hasPagination());


### PR DESCRIPTION
Following the discussion in https://github.com/json-api/json-api/pull/1532.