### PR TITLE
prepare for php 8.4 deprecations

### DIFF
--- a/examples/bootstrap_examples.php
+++ b/examples/bootstrap_examples.php
@@ -142,7 +142,7 @@ class ExampleTimestampsProfile implements ProfileInterface {
 	 * optionally helpers for the specific profile
 	 */
 	
-	public function setTimestamps(ResourceInterface $resource, \DateTimeInterface $created=null, \DateTimeInterface $updated=null) {
+	public function setTimestamps(ResourceInterface $resource, ?\DateTimeInterface $created=null, ?\DateTimeInterface $updated=null) {
 		if ($resource instanceof ResourceIdentifierObject) {
 			throw new Exception('cannot add attributes to identifier objects');
 		}

--- a/src/ErrorsDocument.php
+++ b/src/ErrorsDocument.php
@@ -29,7 +29,7 @@ class ErrorsDocument extends Document {
 	];
 	
 	/**
-	 * @param ErrorObject $errorObject optional
+	 * @param ?ErrorObject $errorObject optional
 	 */
 	public function __construct(?ErrorObject $errorObject=null) {
 		parent::__construct();

--- a/src/ErrorsDocument.php
+++ b/src/ErrorsDocument.php
@@ -31,7 +31,7 @@ class ErrorsDocument extends Document {
 	/**
 	 * @param ErrorObject $errorObject optional
 	 */
-	public function __construct(ErrorObject $errorObject=null) {
+	public function __construct(?ErrorObject $errorObject=null) {
 		parent::__construct();
 		
 		if ($errorObject !== null) {

--- a/tests/example_output/ExampleTimestampsProfile.php
+++ b/tests/example_output/ExampleTimestampsProfile.php
@@ -11,7 +11,7 @@ class ExampleTimestampsProfile implements ProfileInterface {
 		return 'https://jsonapi.org/recommendations/#authoring-profiles';
 	}
 	
-	public function setTimestamps(ResourceInterface $resource, \DateTimeInterface $created=null, \DateTimeInterface $updated=null) {
+	public function setTimestamps(ResourceInterface $resource, ?\DateTimeInterface $created=null, ?\DateTimeInterface $updated=null) {
 		if ($resource instanceof ResourceIdentifierObject) {
 			throw new Exception('cannot add attributes to identifier objects');
 		}


### PR DESCRIPTION
@lode hi 🇸🇪! please consider this deprecation:

Implicitly nullable parameter[ ¶](https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter)