### PR TITLE
Allow mixed value for addSource

### DIFF
--- a/src/objects/ErrorObject.php
+++ b/src/objects/ErrorObject.php
@@ -223,7 +223,7 @@ class ErrorObject extends AbstractObject implements HasLinksInterface, HasMetaIn
 	 * @see ->blameJsonPointer()
 	 * @see ->blameQueryParameter()
 	 */
-	public function addSource(string $key, string $value): void {
+	public function addSource(string $key, mixed $value): void {
 		Validator::checkMemberName($key);
 		
 		$this->source[$key] = $value;


### PR DESCRIPTION
Before the stricter typing we used this like this:

```php
$errorObject->addSource('entity', [
     'type' => $this->type,
     'id'   => $this->id,
 ]);
```

And relied in the processing of validation errors on being able to get `error.source.entity.id`
This change forces us to use a string as the entity identifier, which would either make us lose the type or id context, or require extra work on the receiving end to split the string value of `$type . ' ' . $id` given as a string. 